### PR TITLE
Add GNOME desktop icon to start read.py script

### DIFF
--- a/raspi_air.desktop
+++ b/raspi_air.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Raspi Air
+Exec=python3 /path/to/read.py
+Icon=/path/to/icon.png
+Type=Application


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DerSchimi/raspi_air/pull/12?shareId=120ebd2b-326a-4601-98dd-fa79d0bdc1c6).